### PR TITLE
Replace .all with a function that takes language

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const pokemon = require('./data/en');
 const repoUrl = 'https://github.com/sindresorhus/pokemon';
 const reportText = `Please report to ${repoUrl}/issues if we missed something.`;
 
-exports.all = pokemon;
 exports.random = uniqueRandomArray(pokemon);
 
 const languages = new Set([
@@ -29,6 +28,8 @@ function getLocalizedList(lang) {
 
 	return require(`./data/${lang.toLowerCase()}`);
 }
+
+exports.all = getLocalizedList;
 
 exports.getName = (id, lang) => {
 	const list = getLocalizedList(lang);

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ $ npm install --save pokemon
 ```js
 const pokemon = require('pokemon');
 
+pokemon.all();
+//=> ['Bulbasaur', ...]
+
 pokemon.random();
 //=> 'Snorlax'
 
@@ -32,9 +35,20 @@ pokemon.getId('Dratini');
 
 ## API
 
-### .all: *string[]*
+### .all(lang: *string* = 'en'): *string[]*
 
-All names.
+Get a list of all names.
+
+#### lang
+
+[Language code](#supported-languages) to retrieve the list of Pokémon for.
+
+```js
+pokemon.all();
+//=> ['Bulbasaur', ...]
+pokemon.all('de');
+//=> ['Bisasam', ...]
+```
 
 ### .random(): *string*
 
@@ -44,7 +58,9 @@ Random name.
 
 Get name from ID.
 
-With the optional `lang` parameter you can get a localized name using a [language code](https://en.wikipedia.org/wiki/ISO_639-1):
+#### lang
+
+[Language code](#supported-languages) to retrieve the Pokémon for.
 
 ```js
 pokemon.getName(100);
@@ -57,7 +73,9 @@ pokemon.getName(100, 'de');
 
 Get ID from name.
 
-With the optional `lang` parameter you can get the ID for a localized name using a [language code](https://en.wikipedia.org/wiki/ISO_639-1):
+#### lang
+
+[Language code](#supported-languages) of the localized name.
 
 ```js
 pokemon.getId('Snorlax');
@@ -86,6 +104,7 @@ Pokémon names are available for the following languages:
 - `zh-Hans` (Simplified Chinese)
 - `zh-Hant` (Traditional Chinese)
 
+The language codes follow the [IETF BCP 47 standard.](https://en.wikipedia.org/wiki/IETF_language_tag)
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,10 @@
 import test from 'ava';
 import m from './';
 
+function testAll(t, lang, expectedNames) {
+	t.deepEqual(m.all(lang).slice(0, 3), expectedNames);
+}
+
 function testNames(t, lang, expectedNames) {
 	t.is(m.getName(1, lang), expectedNames[0]);
 	t.is(m.getName(400, lang), expectedNames[1]);
@@ -17,8 +21,6 @@ test('default', t => {
 	t.true(m.all.length > 0);
 	t.truthy(m.random());
 	t.not(m.random(), m.random());
-	t.is(m.all[0], 'Bulbasaur');
-	t.is(m.all[1], 'Ivysaur');
 	t.is(m.getName(143), 'Snorlax');
 	t.is(m.getId('Snorlax'), 143);
 });
@@ -27,6 +29,18 @@ test('.languages', t => {
 	t.true(m.languages.has('en'));
 	t.true(m.languages.has('de'));
 });
+
+test('Get all English names', testAll, 'en', [
+	'Bulbasaur',
+	'Ivysaur',
+	'Venusaur'
+]);
+
+test('Get all German names', testAll, 'de', [
+	'Bisasam',
+	'Bisaknosp',
+	'Bisaflor'
+]);
 
 test('Get English name by ID', testNames, 'en', [
 	'Bulbasaur',


### PR DESCRIPTION
Resolves #18.

Replaced .all with a function that takes language. (or defaults to English)

This will require a major version increase as it is a breaking change.