### PR TITLE
Fix german name for Ho-Oh

### DIFF
--- a/data/de.json
+++ b/data/de.json
@@ -248,7 +248,7 @@
 	"Pupitar",
 	"Despotar",
 	"Lugia",
-	"Oh",
+	"Ho-Oh",
 	"Celebi",
 	"Geckarbor",
 	"Reptain",


### PR DESCRIPTION
Fixed Ho-Ohs name according to the official Pokédex.

https://www.pokemon.com/de/pokedex/ho-oh