### PR TITLE
Fix french name for Ho-Oh

### DIFF
--- a/data/fr.json
+++ b/data/fr.json
@@ -248,7 +248,7 @@
 	"Ymphect",
 	"Tyranocif",
 	"Lugia",
-	"Oh",
+	"Ho-Oh",
 	"Celebi",
 	"Arcko",
 	"Massko",


### PR DESCRIPTION
Apparently the same issue as in https://github.com/sindresorhus/pokemon/pull/32.

https://www.pokemon.com/fr/pokedex/ho-oh