### PR TITLE
Fix a French Pokemon name

### DIFF
--- a/data/fr.json
+++ b/data/fr.json
@@ -120,7 +120,7 @@
 	"Poissoroy",
 	"Stari",
 	"Staross",
-	"Mime",
+	"M. Mime",
 	"Insécateur",
 	"Lippoutou",
 	"Élektek",


### PR DESCRIPTION
Fixes #38 
As you can see in the following link, the name of Mime in french is M. Mime
https://www.pokemon.com/fr/pokedex/m-mime