### PR TITLE
Fixed typo in Munkidori (en.json)

### DIFF
--- a/data/en.json
+++ b/data/en.json
@@ -1013,7 +1013,7 @@
 	"Poltchageist",
 	"Sinistcha",
 	"Okidogi",
-	"Mankidori",
+	"Munkidori",
 	"Fezandipiti",
 	"Ogerpon",
 	"Archaludon",


### PR DESCRIPTION
There is a typo in the English JSON file. `Mankidori` should be `Munkidori`.